### PR TITLE
Aggiunta sezione AdR

### DIFF
--- a/appendix/bibliography.bib
+++ b/appendix/bibliography.bib
@@ -67,3 +67,13 @@
     title   = {localhost},
     url     = {https://supporthost.com/it/localhost/#localhost-cose/}
 }
+
+@online{ieee-std-610-12-1990,
+    title   = {IEEE Std 610.12-1990},
+    url     = {https://www.informatik.htw-dresden.de/~hauptman/SEI/IEEE_Standard_Glossary_of_Software_Engineering_Terminology%20.pdf}
+}
+
+@online{wcag,
+    title   = {Web Content Accessibility Guidelines (WCAG)},
+    url     = {https://www.w3.org/Translations/WCAG22-it/#background-on-wcag-2}
+}

--- a/appendix/glossary-entries.tex
+++ b/appendix/glossary-entries.tex
@@ -1,185 +1,188 @@
 % Acronyms
-\newacronym[description={\glslink{seog}{Search Engine Optimization}}]
+\newacronym[description={\glslink{seog}{Search Engine Optimization}.}]
     {seo}{SEO}{Search Engine Optimization}
 
-\newacronym[description={\glslink{json-ldg}{JavaScript Object Notation for Linked Data}}]
+\newacronym[description={\glslink{json-ldg}{JavaScript Object Notation for Linked Data}.}]
     {json-ld}{JSON-LD}{JavaScript Object Notation for Linked Data}
 
-\newacronym[description={\glslink{serpg}{Search Engine Results Page}}]
+\newacronym[description={\glslink{serpg}{Search Engine Results Page}.}]
     {serp}{SERP}{Search Engine Results Page}
 
-\newacronym[description={\glslink{csvg}{Comma Separated Values}}]
+\newacronym[description={\glslink{csvg}{Comma Separated Values}.}]
     {csv}{CSV}{Comma Separated Values}
 
-\newacronym[description={\glslink{gscg}{Google Search Console}}]
+\newacronym[description={\glslink{gscg}{Google Search Console}.}]
     {gsc}{GSC}{Google Search Console}
 
-\newacronym[description={\glslink{cmsg}{Content Management System}}]
+\newacronym[description={\glslink{cmsg}{Content Management System}.}]
     {cms}{CMS}{Content Management System}
 
-\newacronym[description={\glslink{wcagg}{Web Content Accessibility Guidelines}}]
+\newacronym[description={\glslink{wcagg}{Web Content Accessibility Guidelines}.}]
     {wcag}{WCAG}{Web Content Accessibility Guidelines}
+
+\newacronym[description={\glslink{htmlg}{HyperText Markup Language}.}]
+    {html}{HTML}{HyperText Markup Language}
 
 % Glossary entries
 \newglossaryentry{seog} {
     name=\glslink{seo}{SEO},
     text=SEO,
     sort=seo,
-    description={Con il termine \emph{SEO, Search Engine Optimization} (ing. ottimizzazione per i motori di ricerca) si intende un processo volto a migliorare il posizionamento di un contenuto web nella pagina dei risultati dei motori di ricerca}
+    description={Con il termine \emph{SEO, Search Engine Optimization} (ing. ottimizzazione per i motori di ricerca) si intende un processo volto a migliorare il posizionamento di un contenuto web nella pagina dei risultati dei motori di ricerca.}
 }
 
 \newglossaryentry{on-page-seo} {
     name=\glslink{on-page-seo}{SEO on-page},
     text=on-page,
     sort=on-page-seo,
-    description={Con il termine \emph{SEO on-page} si intende il processo di ottimizzazione degli elementi interni a una pagina web, come i metadati, i contenuti, i link, gli URL e altri fattori di ranking}
+    description={Con il termine \emph{SEO on-page} si intende il processo di ottimizzazione degli elementi interni a una pagina web, come i metadati, i contenuti, i link, gli URL e altri fattori di ranking.}
 }
 
 \newglossaryentry{off-page-seo} {
     name=\glslink{off-page-seo}{SEO off-page},
     text=off-page,
     sort=off-page-seo,
-    description={Con il termine \emph{SEO off-page} si intende l'insieme di strategie implementate al di fuori di un sito web, con l'obiettivo di aumentarne l'autorevolezza e la visibilità}
+    description={Con il termine \emph{SEO off-page} si intende l'insieme di strategie implementate al di fuori di un sito web, con l'obiettivo di aumentarne l'autorevolezza e la visibilità.}
 }
 
 \newglossaryentry{hreflang} {
     name=\glslink{hreflang}{Hreflang},
     text=Hreflang,
     sort=hreflang,
-    description={\emph{Hreflang} è un attributo HTML utilizzato per indicare ai motori di ricerca la lingua e il targeting geografico di una pagina web}
+    description={\emph{Hreflang} è un attributo HTML utilizzato per indicare ai motori di ricerca la lingua e il targeting geografico di una pagina web.}
 }
 
 \newglossaryentry{tag-canonical} {
     name=\glslink{tag-canonical}{Tag canonical},
     text=tag canonical,
     sort=tag-canonical,
-    description={Il \emph{tag canonical} è un elemento HTML utilizzato per evitare problemi relativi a contenuti "duplicati" presenti su più URL}
+    description={Il \emph{tag canonical} è un elemento HTML utilizzato per evitare problemi relativi a contenuti "duplicati" presenti su più URL.}
 }
 
 \newglossaryentry{sitemap} {
     name=\glslink{sitemap}{Sitemap},
     text=sitemap,
     sort=Sitemap,
-    description={Una \emph{sitemap} è un file che elenca gerarchicamente le pagine di un sito web}
+    description={Una \emph{sitemap} è un file che elenca gerarchicamente le pagine di un sito web.}
 }
 
 \newglossaryentry{tag-robots} {
     name=\glslink{tag-robots}{Tag `robots`},
     text=tag `robots`,
     sort=tag-robots,
-    description={I \emph{meta tag `robots`} forniscono istruzioni su come scansionare e indicizzare una pagina web}
+    description={I \emph{meta tag `robots`} forniscono istruzioni su come scansionare e indicizzare una pagina web.}
 }
 
 \newglossaryentry{json-ldg} {
     name=\glslink{json-ld}{JSON-LD},
     text=JSON-LD,
     sort=json-ld,
-    description={Con il termine \emph{JSON-LD, JavaScript Object Notation for Linked Data} si intende un formato di dati strutturati che utilizza la sintassi JSON per arricchire il contenuto di una pagina web}
+    description={Con il termine \emph{JSON-LD, JavaScript Object Notation for Linked Data} si intende un formato di dati strutturati che utilizza la sintassi JSON per arricchire il contenuto di una pagina web.}
 }
 
 \newglossaryentry{case-sensitive} {
     name=\glslink{case-sensitive}{Case-sensitive},
     text=case-sensitive,
     sort=case-sensitive,
-    description={Un’operazione di analisi del testo si definisce \emph{case-sensitive} se distingue tra parole che differiscono solo per l’uso di lettere maiuscole o minuscole}
+    description={Un'operazione di analisi del testo si definisce \emph{case-sensitive} se distingue tra parole che differiscono solo per l'uso di lettere maiuscole o minuscole.}
 }
 
 \newglossaryentry{serpg} {
     name=\glslink{serp}{SERP},
     text=SERP,
     sort=serp,
-    description={Con il termine \emph{SERP, Search Engine Results Page} (ing. pagina dei risultati del motore di ricerca) si intende la pagina generata dal motore di ricerca in risposta a una query dell'utente}
+    description={Con il termine \emph{SERP, Search Engine Results Page} (ing. pagina dei risultati del motore di ricerca) si intende la pagina generata dal motore di ricerca in risposta a una query dell'utente.}
 }
 
 \newglossaryentry{csvg} {
     name=\glslink{csv}{CSV},
     text=CSV,
     sort=csv,
-    description={Con il termine \emph{CSV, Comma Separated Values} (ing. valori separati da virgola) si intende un formato di file utilizzato per l'importazione ed esportazione di una tabella di dati}
+    description={Con il termine \emph{CSV, Comma Separated Values} (ing. valori separati da virgola) si intende un formato di file utilizzato per l'importazione ed esportazione di una tabella di dati.}
 }
 
 \newglossaryentry{backlink} {
     name=\glslink{backlink}{Backlink},
     text=backlink,
     sort=backlink,
-    description={Un \emph{backlink} è un link ipertestuale che punta a un sito web partendo da un altro dominio}
+    description={Un \emph{backlink} è un link ipertestuale che punta a un sito web partendo da un altro dominio.}
 }
 
 \newglossaryentry{gscg} {
     name=\glslink{gsc}{GSC},
     text=GSC,
     sort=gsc,
-    description={Con il termine \emph{GSC, Google Search Console} si intende un servizio offerto da Google per monitorare il posizionamento di un sito web}
+    description={Con il termine \emph{GSC, Google Search Console} si intende un servizio offerto da Google per monitorare il posizionamento di un sito web.}
 }
 
 \newglossaryentry{wordpress} {
     name=\glslink{wordpress}{WordPress},
     text=WordPress,
     sort=wordpress,
-    description={WordPress è una piattaforma che consente di creare e gestire siti web (blog, e-commerce, ecc.)}
+    description={\emph{WordPress} è una piattaforma che consente di creare e gestire siti web (blog, e-commerce, ecc.).}
 }
 
 \newglossaryentry{shopify} {
     name=\glslink{shopify}{Shopify},
     text=Shopify,
     sort=shopify,
-    description={Shopify è una piattaforma che consente di creare e gestire e-commerce}
+    description={\emph{Shopify} è una piattaforma che consente di creare e gestire e-commerce.}
 }
 
 \newglossaryentry{cmsg} {
     name=\glslink{cms}{CMS},
     text=CMS,
     sort=cms,
-    description={Con il termine \emph{CMS, Content Management System} (ing. sistema di gestione dei contenuti) si intende un software, come \gls{wordpress} o \gls{shopify}, che consente di creare e gestire siti web senza richiedere competenze tecniche avanzate}
+    description={Con il termine \emph{CMS, Content Management System} (ing. sistema di gestione dei contenuti) si intende un software, come \gls{wordpress} o \gls{shopify}, che consente di creare e gestire siti web senza richiedere competenze tecniche avanzate.}
 }
 
 \newglossaryentry{keyword-difficulty} {
     name=\glslink{keyword-difficulty}{Keyword difficulty},
     text=keyword difficulty,
     sort=keyword-difficulty,
-    description={La \emph{keyword difficulty} è una metrica SEO che stima la difficoltà di posizionarsi per una specifica parola chiave}
+    description={La \emph{keyword difficulty} è una metrica SEO che stima la difficoltà di posizionarsi per una specifica parola chiave.}
 }
 
 \newglossaryentry{keyword-stuffing} {
     name=\glslink{keyword-stuffing}{Keyword stuffing},
     text=keyword stuffing,
     sort=keyword-stuffing,
-    description={Il \emph{keyword stuffing} è una pratica SEO che consiste nell'utilizzo eccessivo e innaturale di una parola chiave, con l'intento di ottenere un miglior posizionamento}
+    description={Il \emph{keyword stuffing} è una pratica SEO che consiste nell'utilizzo eccessivo e innaturale di una parola chiave, con l'intento di ottenere un miglior posizionamento.}
 }
 
 \newglossaryentry{localhost} {
     name=\glslink{localhost}{localhost},
     text=localhost,
     sort=localhost,
-    description={In un ambiente web, \emph{localhost} rappresenta il server locale}
+    description={In un ambiente web, \emph{localhost} rappresenta il server locale.}
 }
 
 \newglossaryentry{organiche} {
     name=\glslink{organiche}{Ricerche organiche},
     text=organiche,
     sort=ricerche-organiche,
-    description={Le ricerche organiche sono i risultati non a pagamento generati dai motori di ricerca}
+    description={Le \emph{ricerche organiche} sono i risultati non a pagamento generati dai motori di ricerca.}
 }
 
 \newglossaryentry{sponsorizzate} {
     name=\glslink{sponsorizzate}{Ricerche sponsorizzate},
     text=sponsorizzate,
     sort=ricerche-sponsorizzate,
-    description={Le ricerche sponsorizzate sono i risultati a pagamento generati dai motori di ricerca}
+    description={Le \emph{ricerche sponsorizzate} sono i risultati a pagamento generati dai motori di ricerca.}
 }
 
 \newglossaryentry{long-tail-keywords} {
     name=\glslink{long-tail-keywords}{Long-tail keywords},
     text=long-tail keywords,
     sort=long-tail-keywords,
-    description={Le long-tail keywords sono frasi con un intento di ricerca preciso}
+    description={Le \emph{long-tail keywords} sono frasi con un intento di ricerca preciso.}
 }
 
 \newglossaryentry{requisiti} {
     name=\glslink{requisiti}{Requisito software},
     text=requisiti,
     sort=requisiti,
-    description={Secondo lo standard IEEE 610.12-1990, un requisito è:
+    description={Secondo lo standard IEEE 610.12-1990, un \emph{requisito} è:
     \begin{enumerate}
         \item Una condizione o capacità di cui un utente ha bisogno per risolvere un problema o raggiungere un obiettivo;
         \item Una condizione o capacità che un sistema (o un suo componente) deve soddisfare o possedere per adempiere a un contratto, una norma, una specifica o altri documenti formalmente imposti;
@@ -188,38 +191,45 @@
     }
 }
 
-\newglossaryentry{github} {
-    name=\glslink{github}{GitHub},
-    text=GitHub,
-    sort=github,
-    description={GitHub è un servizio di hosting per progetti software che utilizza  per facilitare la collaborazione}
-}
-
 \newglossaryentry{use-case} {
     name=\glslink{use-case}{Caso d'uso},
     text=Casi d'uso,
-    sort=use-case,
-    description={Un caso d'uso è una descrizione, testuale e/o visiva, di uno scenario di interazione tra un attore e il sistema. È utilizzato nei processi di ingegneria del software per raccogliere i requisiti funzionali}
+    sort=caso-duso,
+    description={Un \emph{caso d'uso} è una descrizione, testuale e/o visiva, di uno scenario di interazione tra un attore e il sistema. È utilizzato nei processi di ingegneria del software per raccogliere i requisiti funzionali.}
 }
 
 \newglossaryentry{user-story} {
     name=\glslink{user-story}{User story},
     text=User story,
     sort=user-story,
-    description={Una user story è una descrizione informale, in linguaggio naturale, di una funzionalità del sistema, focalizzata sul valore che quest'ultima porta all'utente}
+    description={Una \emph{user story} è una descrizione informale, in linguaggio naturale, di una funzionalità del sistema, focalizzata sul valore che quest'ultima porta all'utente.}
 }
 
 \newglossaryentry{wcagg} {
     name=\glslink{wcag}{WCAG},
     text=WCAG,
     sort=wcag,
-    description={Con il termine \emph{WCAG, Web Content Accessibility Guidelines} (ing. linee guida per l'accessibilità dei contenuti web) si intende un insieme di specifiche tecniche finalizzate a rendere i contenuti web più accessibili alle persone con disabilità}
+    description={Con il termine \emph{WCAG, Web Content Accessibility Guidelines} (ing. linee guida per l'accessibilità dei contenuti web) si intende un insieme di specifiche tecniche finalizzate a rendere i contenuti web più accessibili alle persone con disabilità.}
 }
 
-%\newglossaryentry{git} {
-    %name=\glslink{git}{Git},
-    %text=Git,
-    %sort=git,
-    %description={Git è un software per il controllo di versione, utilizzato per tracciare le modifiche apportate al codice sorgente durante lo sviluppo}
-%}
+\newglossaryentry{github} {
+    name=\glslink{github}{GitHub},
+    text=GitHub,
+    sort=github,
+    description={\emph{GitHub} è un servizio di hosting per progetti software che utilizza \gls{git} per facilitare la collaborazione.}
+}
+
+\newglossaryentry{git} {
+    name=\glslink{git}{Git},
+    text=Git,
+    sort=git,
+    description={\emph{Git} è un software per il controllo di versione, utilizzato per tracciare le modifiche apportate al codice sorgente durante lo sviluppo.}
+}
+
+\newglossaryentry{htmlg} {
+    name=\glslink{html}{HTML},
+    text=HTML,
+    sort=html,
+    description={Con il termine \emph{HTML, HyperText Markup Language} (ing. linguaggio di marcatura d'ipertesto) si intende un linguaggio di markup utilizzato per definire la struttura e i contenuti delle pagine web.}
+}
 

--- a/appendix/glossary-entries.tex
+++ b/appendix/glossary-entries.tex
@@ -17,6 +17,9 @@
 \newacronym[description={\glslink{cmsg}{Content Management System}}]
     {cms}{CMS}{Content Management System}
 
+\newacronym[description={\glslink{wcagg}{Web Content Accessibility Guidelines}}]
+    {wcag}{WCAG}{Web Content Accessibility Guidelines}
+
 % Glossary entries
 \newglossaryentry{seog} {
     name=\glslink{seo}{SEO},
@@ -171,3 +174,52 @@
     sort=long-tail-keywords,
     description={Le long-tail keywords sono frasi con un intento di ricerca preciso}
 }
+
+\newglossaryentry{requisiti} {
+    name=\glslink{requisiti}{Requisito software},
+    text=requisiti,
+    sort=requisiti,
+    description={Secondo lo standard IEEE 610.12-1990, un requisito è:
+    \begin{enumerate}
+        \item Una condizione o capacità di cui un utente ha bisogno per risolvere un problema o raggiungere un obiettivo;
+        \item Una condizione o capacità che un sistema (o un suo componente) deve soddisfare o possedere per adempiere a un contratto, una norma, una specifica o altri documenti formalmente imposti;
+        \item Una rappresentazione documentata di una condizione o capacità come descritto in (1) o (2).
+    \end{enumerate}
+    }
+}
+
+\newglossaryentry{github} {
+    name=\glslink{github}{GitHub},
+    text=GitHub,
+    sort=github,
+    description={GitHub è un servizio di hosting per progetti software che utilizza  per facilitare la collaborazione}
+}
+
+\newglossaryentry{use-case} {
+    name=\glslink{use-case}{Caso d'uso},
+    text=Casi d'uso,
+    sort=use-case,
+    description={Un caso d'uso è una descrizione, testuale e/o visiva, di uno scenario di interazione tra un attore e il sistema. È utilizzato nei processi di ingegneria del software per raccogliere i requisiti funzionali}
+}
+
+\newglossaryentry{user-story} {
+    name=\glslink{user-story}{User story},
+    text=User story,
+    sort=user-story,
+    description={Una user story è una descrizione informale, in linguaggio naturale, di una funzionalità del sistema, focalizzata sul valore che quest'ultima porta all'utente}
+}
+
+\newglossaryentry{wcagg} {
+    name=\glslink{wcag}{WCAG},
+    text=WCAG,
+    sort=wcag,
+    description={Con il termine \emph{WCAG, Web Content Accessibility Guidelines} (ing. linee guida per l'accessibilità dei contenuti web) si intende un insieme di specifiche tecniche finalizzate a rendere i contenuti web più accessibili alle persone con disabilità}
+}
+
+%\newglossaryentry{git} {
+    %name=\glslink{git}{Git},
+    %text=Git,
+    %sort=git,
+    %description={Git è un software per il controllo di versione, utilizzato per tracciare le modifiche apportate al codice sorgente durante lo sviluppo}
+%}
+

--- a/chapters/concept.tex
+++ b/chapters/concept.tex
@@ -1,78 +1,444 @@
 \chapter{Analisi dei requisiti}
 \label{cap:analisi-requisiti}
 
-\intro{Breve introduzione al capitolo}\\
+\par L'analisi dei \gls{requisiti} è stata condotta seguendo gli standard dell'ingegneria del software, integrando l'analisi del progetto e delle soluzioni esistenti con colloqui e dialoghi con la Proponente. In questa sezione sono illustrati i seguenti punti:
+\begin{itemize}
+    \item \textbf{\gls{use-case}}: descrizione e diagrammi dei casi d'uso;
+    \item \textbf{Tracciamento dei requisiti};
+    \item \textbf{\gls{user-story}}.
+\end{itemize}
 
 \section{Casi d'uso}
 
-Per lo studio dei casi di utilizzo del prodotto sono stati creati dei diagrammi.
-I diagrammi dei casi d'uso (in inglese \emph{Use Case Diagram}) sono diagrammi di tipo \gls{uml} dedicati alla descrizione delle funzioni o servizi offerti da un sistema, così come sono percepiti e utilizzati dagli attori che interagiscono col sistema stesso.
-Essendo il progetto finalizzato alla creazione di un tool per l'automazione di un processo, le interazioni da parte dell'utilizzatore devono essere ovviamente ridotte allo stretto necessario. Per questo motivo i diagrammi d'uso risultano semplici e in numero ridotto.
+\paragraph*{Attori}\\
+\par L'unico attore coinvolto nell'interazione con il sistema è un \textbf{utente generico} con accesso completo alla funzionalità di analisi \gls{seog}. Di seguito sono elencate alcune tipologie di utenti a cui è rivolto il progetto:
+\begin{itemize}
+    \item \textbf{Sviluppatore}: utilizza l'estensione durante lo sviluppo e la produzione di contenuti web;
+    \item \textbf{Tester}: effettua un'analisi SEO per identificare eventuali problemi e proporre azioni di miglioramento;
+    \item \textbf{Professore}: utilizza l'estensione per analizzare progetti didattici.
+\end{itemize}
 
-\begin{figure}[!h] 
-    \centering 
-    \includegraphics[width=0.9\columnwidth]{usecase/scenario-principale} 
-    \caption{Use Case - UC0: Scenario principale}
-\end{figure}
-
-\begin{usecase}{0}{Scenario principale}
-\usecaseactors{Sviluppatore applicativi}
-\usecasepre{Lo sviluppatore è entrato nel plug-in di simulazione all'interno dell'IDE}
-\usecasedesc{La finestra di simulazione mette a disposizione i comandi per configurare, registrare o eseguire un test}
-\usecasepost{Il sistema è pronto per permettere una nuova interazione}
-\label{uc:scenario-principale}
+\begin{usecase}{1}{Accesso alla funzionalità di analisi delle parole chiave}\label{UC1}
+    \usecaseactors{Utente.}
+    \usecasepre{L'utente ha avviato l'estensione.}
+    \usecasedesc{L'utente seleziona la funzionalità di analisi delle parole chiave.}
+    \usecasepost{Il sistema mostra la schermata di analisi delle parole chiave.}
 \end{usecase}
 
-\section{Tracciamento dei requisiti}
+\begin{usecase}{2}{Visualizzazione di una panoramica dell'analisi delle parole chiave}\label{UC2}
+    \usecaseactors{Utente.}
+    \usecasepre{
+        \begin{itemize}
+            \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+            \item Il sistema è attivo e funzionante.
+        \end{itemize}
+    }
+    \usecasepost{Il sistema mostra una panoramica dell'analisi delle parole chiave.}
+    \usecasesub{
+        \begin{itemize}
+            \item \hyperref[UC2point1]{UC2.1}: Visualizzazione del meta tag keywords;
+            \item \hyperref[UC2point2]{UC2.2}: Visualizzazione del numero totale di parole nella pagina;
+            \item \hyperref[UC2point3]{UC2.3}: Visualizzazione del numero di parole uniche nella pagina;
+            \item \hyperref[UC2point4]{UC2.4}: Visualizzazione della lingua della pagina.
+        \end{itemize}}
+\end{usecase}
 
-Da un'attenta analisi dei requisiti e degli use case effettuata sul progetto è stata stilata la tabella che traccia i requisiti in rapporto agli use case.\\
-Sono stati individuati diversi tipi di requisiti e si è quindi fatto utilizzo di un codice identificativo per distinguerli.\\
-Il codice dei requisiti è così strutturato R(F/Q/V)(N/D/O) dove:
-\begin{enumerate}
-	\item[R =] requisito
-    \item[F =] funzionale
-    \item[Q =] qualitativo
-    \item[V =] di vincolo
-    \item[N =] obbligatorio (necessario)
-    \item[D =] desiderabile
-    \item[Z =] opzionale
-\end{enumerate}
-Nelle tabelle \ref{tab:requisiti-funzionali}, \ref{tab:requisiti-qualitativi} e \ref{tab:requisiti-vincolo} sono riassunti i requisiti e il loro tracciamento con gli use case delineati in fase di analisi.
+\begin{usecase}{2.1}{Visualizzazione del meta tag keywords}\label{UC2point1}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra il meta tag keywords.}
+    \usecaseext{
+        \begin{itemize}
+            \item Visualizzazione di un avviso se il meta tag keywords non è presente (\hyperref[UC10]{UC10}).
+        \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{2.2}{Visualizzazione del numero totale di parole nella pagina}\label{UC2point2}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema il numero totale di parole presenti nella pagina.}
+\end{usecase}
+
+\begin{usecase}{2.3}{Visualizzazione del numero di parole uniche nella pagina}\label{UC2point3}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra il numero totale di parole uniche presenti nella pagina.}
+\end{usecase}
+
+\begin{usecase}{2.4}{Visualizzazione della lingua della pagina}\label{UC2point4}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra la lingua della pagina.}
+\end{usecase}
+
+\begin{usecase}{3}{Inserimento di una parola chiave}\label{UC3}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasedesc{L'utente digita una parola chiave da analizzare.}
+    \usecasepost{Il sistema mostra la parola chiave inserita dall'utente nell'apposito campo di testo.}
+\end{usecase}
+
+\begin{usecase}{4}{Inserimento di una parola chiave}\label{UC4}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasedesc{Il sistema esegue l'analisi di una parola chiave scelta dall'utente.}
+    \usecasepost{Il sistema aggiunge la parola chiave analizzata alla lista delle keyword.}
+    \usecaseinc{\begin{itemize}
+        \item Inserimento di una parola chiave (\hyperref[UC3]{UC3}).
+    \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{5}{Visualizzazione di una lista delle parole chiave}\label{UC5}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra una lista delle parole chiave.}
+    \usecasesub{
+        \begin{itemize}
+            \item \hyperref[UC5point1]{UC5.1}: Visualizzazione di una lista delle parole chiave estratte dal meta tag keywords;
+            \item \hyperref[UC5point2]{UC5.2}: Visualizzazione di una lista delle parole chiave inserite dall'utente;
+            \item \hyperref[UC5point3]{UC5.3}: Visualizzazione di una lista delle parole chiave più frequenti.
+        \end{itemize}}
+    \usecaseinc{\begin{itemize}
+        \item Visualizzazione di una singola parola chiave (\hyperref[UC6]{UC6}).
+    \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{5.1}{Visualizzazione di una lista delle parole chiave}\label{UC5point1}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra una lista delle parole chiave estratte dal meta tag keywords.}
+\end{usecase}
+
+\begin{usecase}{5.2}{Visualizzazione di una lista delle parole chiave inserite dall'utente}\label{UC5point2}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra una lista delle parole chiave inserite dall'utente.}
+\end{usecase}
+
+\begin{usecase}{5.3}{Visualizzazione di una lista delle parole chiave inserite dall'utente}\label{UC5point3}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra una lista delle parole chiave più frequenti.}
+\end{usecase}
+
+\begin{usecase}{6}{Visualizzazione di una singola parola chiave}\label{UC6}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante;
+        \item È visibile la lista delle parole chiave.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza una singola parola chiave.}
+    \usecaseinc{\begin{itemize}
+        \item Visualizzazione dei risultati dell'analisi di una parola chiave (\hyperref[UC7]{UC7}).
+    \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{7}{Visualizzazione dei risultati dell'analisi di una parola chiave}\label{UC7}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza i risultati dell'analisi di una parola chiave.}
+    \usecasesub{
+        \begin{itemize}
+            \item \hyperref[UC7point1]{UC7.1}: Visualizzazione della frequenza di una parola chiave;
+            \item \hyperref[UC7point2]{UC7.2}: Visualizzazione della densità di una parola chiave;
+            \item \hyperref[UC7point3]{UC7.3}: Visualizzazione di un elenco dei tag in cui dovrebbe essere presente una parola chiave.
+        \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{7.1}{Visualizzazione della frequenza di una parola chiave}\label{UC7point1}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza la frequenza di una parola chiave.}
+\end{usecase}
+
+\begin{usecase}{7.2}{Visualizzazione della densità di una parola chiave}\label{UC7point2}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza la densità di una parola chiave.}
+    \usecaseext{\begin{itemize}
+        \item Visualizzazione di un avviso se la densità di una parola chiave è troppo alta (\hyperref[UC11]{UC11}).
+    \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{7.3}{Visualizzazione di un elenco dei tag in cui dovrebbe essere presente una parola chiave}\label{UC7point3}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza un elenco dei tag in cui dovrebbe essere presente una parola chiave.}
+    \usecasesub{\begin{itemize}
+        \item \hyperref[UC7point3point1]{UC7.3.1}: Visualizzazione di un singolo tag.
+    \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{7.3.1}{Visualizzazione di un singolo tag}\label{UC7point3point1}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante;
+        \item L'utente sta visualizzando i risultati dell'analisi di una parola chiave;
+        \item È visibile l'elenco dei tag.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza un singolo tag.}
+    \usecasesub{\begin{itemize}
+        \item \hyperref[UC7point3point1point1]{UC7.3.1.1}: Visualizzazione del nome del tag;
+        \item \hyperref[UC7point3point1point2]{UC7.3.1.2}: Visualizzazione del numero di occorrenze della parola chiave nel tag.
+    \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{7.3.1.1}{Visualizzazione del nome del tag}\label{UC7point3point1point1}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza il nome del tag.}
+\end{usecase}
+
+\begin{usecase}{7.3.1.2}{Visualizzazione del numero di occorrenze di una parola chiave nel tag}\label{UC7point3point1point2}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{L'utente visualizza il numero di occorrenze della parola chiave nel tag.}
+    \usecaseext{\begin{itemize}
+        \item Visualizzazione di un avviso se il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia (\hyperref[UC12]{UC12}).
+    \end{itemize}}
+\end{usecase}
+
+\begin{usecase}{8}{Evidenziazione di una parola chiave nella pagina}\label{UC8}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema evidenzia graficamente tutte le occorrenze di una parola chiave nella pagina.}
+\end{usecase}
+
+\begin{usecase}{9}{Aggiornamento dell'analisi delle parole chiave}\label{UC9}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasedesc{L'utente attiva manualmente l'aggiornamento dell'analisi delle parole chiave per sincronizzarla con eventuali modifiche dinamiche al DOM.}
+    \usecasepost{Il sistema aggiorna l'analisi delle parole chiave.}
+\end{usecase}
+
+\begin{usecase}{10}{Visualizzazione di un avviso se il meta tag keywords non è presente}\label{UC10}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra un avviso in cui notifica all'utente che il meta tag keywords non è presente.}
+\end{usecase}
+
+\begin{usecase}{11}{Visualizzazione di un avviso se la densità di una parola chiave è troppo alta}\label{UC11}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra un avviso in cui notifica all'utente che la densità di una parola chiave è troppo alta.}
+\end{usecase}
+
+\begin{usecase}{12}{Visualizzazione di un avviso se il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia}\label{UC12}
+    \usecaseactors{Utente.}
+    \usecasepre{\begin{itemize}
+        \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
+        \item Il sistema è attivo e funzionante.
+    \end{itemize}}
+    \usecasepost{Il sistema mostra un avviso in cui notifica all'utente che il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia.}
+\end{usecase}
 
 \newpage
 
-\begin{table}%
-\caption{Tabella del tracciamento dei requisti funzionali}
-\label{tab:requisiti-funzionali}
-\begin{tabularx}{\textwidth}{lXl}
-\hline\hline
-\textbf{Requisito} & \textbf{Descrizione} & \textbf{Use Case}\\
-\hline
-RFN-1     & L'interfaccia permette di configurare il tipo di sonde del test & UC1 \\
-\hline
-\end{tabularx}
-\end{table}%
+\section{Tracciamento dei requisiti}
+\par I requisiti del progetto, individuati e formalizzati durante il processo di analisi, sono illustrati nelle tabelle \ref{tab:requisiti-funzionali}, \ref{tab:requisiti-qualitativi} e \ref{tab:requisiti-vincolo} secondo la seguente notazione:
+\par \textbf{\[R[Tipologia].[Importanza].[Codice]\]} 
+\par dove:
+\par\vspace{20pt}
+\begin{tabular}{@{}ll@{}}
+    R = & requisito \\
+    \textbf{Tipologia}: & \\
+    \quad F = & funzionale \\
+    \quad Q = & di qualità \\
+    \quad V = & di vincolo/dominio \\
+    \textbf{Importanza}: & \\
+    \quad O = & obbligatorio \\
+    \quad D = & desiderabile \\  
+    \quad OP = & opzionale \\
+    Codice = & codice numerico univoco \\
+\end{tabular}
+    
+\newpage
 
-\begin{table}%
-\caption{Tabella del tracciamento dei requisiti qualitativi}
-\label{tab:requisiti-qualitativi}
-\begin{tabularx}{\textwidth}{lXl}
+\renewcommand{\arraystretch}{1.5}
+\begin{longtable}{p{0.15\textwidth}p{0.55\textwidth}p{0.2\textwidth}}
+\caption{Tabella dei requisti funzionali}
+\label{tab:requisiti-funzionali} \\
 \hline\hline
-\textbf{Requisito} & \textbf{Descrizione} & \textbf{Use Case}\\
-\hline
-RQD-1    & Le prestazioni del simulatore hardware deve garantire la giusta esecuzione dei test e non la generazione di falsi negativi & - \\
-\hline
-\end{tabularx}
-\end{table}%
+\textbf{Requisito} & \textbf{Descrizione} & \textbf{Fonti}\\
+\endfirsthead
 
-\begin{table}%
-\caption{Tabella del tracciamento dei requisiti di vincolo}
-\label{tab:requisiti-vincolo}
-\begin{tabularx}{\textwidth}{lXl}
+\caption[]{Tabella dei requisiti funzionali (continua)} \\
 \hline\hline
-\textbf{Requisito} & \textbf{Descrizione} & \textbf{Use Case}\\
+\textbf{Requisito} & \textbf{Descrizione} & \textbf{Fonti} \\ 
+\endhead
+
+\multicolumn{3}{r}{{Continua nella prossima pagina}} \\ 
+\endfoot
+
 \hline
-RVO-1    & La libreria per l'esecuzione dei test automatici deve essere riutilizzabile & - \\
+\endlastfoot
+
 \hline
-\end{tabularx}
-\end{table}%
+RF.O.1 & L'utente deve poter accedere alla funzionalità di analisi delle parole chiave. & \hyperref[UC1]{UC1} \\
+\hline
+RF.O.2 & L'utente deve poter visualizzare una panoramica dell'analisi delle parole chiave. & \hyperref[UC2]{UC2} \\
+\hline
+RF.O.3 & L'utente deve poter visualizzare il meta tag keywords. & \hyperref[UC2point1]{UC2.1} \\
+\hline
+RF.O.4 & L'utente deve poter visualizzare il numero totale di parole nella pagina. & \hyperref[UC2point2]{UC2.2} \\
+\hline
+RF.OP.5 & L'utente deve poter visualizzare il numero di parole uniche nella pagina. & \hyperref[UC2point3]{UC2.3} \\
+\hline
+RF.O.6 & L'utente deve poter visualizzare la lingua della pagina. & \hyperref[UC2point4]{UC2.4} \\
+\hline
+RF.O.7 & L'utente deve poter inserire una parola chiave da analizzare. & \hyperref[UC3]{UC3} \\
+\hline
+RF.O.8 & L'utente deve poter analizzare una parola chiave. & \hyperref[UC4]{UC4} \\
+\hline
+RF.O.9 & L'utente deve poter visualizzare una lista delle parole chiave. & \hyperref[UC5]{UC5} \\
+\hline
+RF.O.10 & L'utente deve poter visualizzare una lista delle parole chiave estratte dal meta tag keywords. & \hyperref[UC5point1]{UC5.1} \\
+\hline
+RF.O.11 & Il sistema deve visualizzare una lista delle parole chiave inserite dall'utente. & \hyperref[UC5point2]{UC5.2} \\
+\hline
+RF.OP.12 & L'utente deve poter visualizzare una lista delle parole chiave più frequenti. & \hyperref[UC5point3]{UC5.3} \\
+\hline
+RF.O.13 & L'utente deve poter visualizzare una singola parola chiave. & \hyperref[UC6]{UC6} \\
+\hline
+RF.O.14 & L'utente deve poter visualizzare i risultati dell'analisi di una parola chiave. & \hyperref[UC7]{UC7} \\
+\hline
+RF.O.15 & L'utente deve poter visualizzare la frequenza di una parola chiave. & \hyperref[UC7point1]{UC7.1} \\
+\hline
+RF.O.16 & L'utente deve poter visualizzare la densità di una parola chiave. & \hyperref[UC7point2]{UC7.2} \\
+\hline
+RF.D.17 & Il sistema deve mostrare un elenco dei tag in cui dovrebbe essere presente una parola chiave. & \hyperref[UC7point3]{UC7.3} \\
+\hline
+RF.D.18 & L'utente deve poter visualizzare un singolo tag. & \hyperref[UC7point3point1]{UC7.3.1} \\
+\hline
+RF.D.19 & L'utente deve poter visualizzare il nome del tag. & \hyperref[UC7point3point1point1]{UC7.3.1.1} \\
+\hline
+RF.D.20 & L'utente deve poter visualizzare il numero di occorrenze di una parola chiave nel tag. & \hyperref[UC7point3point1point2]{UC7.3.1.2} \\
+\hline
+RF.O.21 & Il sistema deve evidenziare tutte le occorrenze di una parola chiave nella pagina. & \hyperref[UC8]{UC8} \\
+\hline
+RF.O.22 & L'utente deve poter aggiornare l'analisi delle parole chiave. & \hyperref[UC9]{UC9} \\
+\hline
+RF.O.23 & Il sistema deve mostrare un avviso se il meta tag keywords non è presente. & \hyperref[UC10]{UC10} \\
+\hline
+RF.O.24 & Il sistema deve mostrare un avviso se la densità di una parola chiave è troppo alta. & \hyperref[UC11]{UC11} \\
+\hline
+RF.D.25 & Il sistema deve mostrare un avviso se il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia. & \hyperref[UC12]{UC12} \\
+\hline
+RF.O.26 & Il sistema deve evidenziare le parole chiave con colori diversi in base al tag HTML che le racchiude. & Discussione con la Proponente \\
+\end{longtable}
+
+\newpage
+
+\renewcommand{\arraystretch}{1.5}
+\begin{longtable}{p{0.15\textwidth}p{0.55\textwidth}p{0.2\textwidth}}
+\caption{Tabella dei requisti di qualità}
+\label{tab:requisiti-qualitativi} \\
+\hline\hline
+\textbf{Requisito} & \textbf{Descrizione} & \textbf{Fonti}\\
+\endfirsthead
+    
+\caption[]{Tabella dei requisiti di qualità (continua)} \\
+\hline\hline
+\textbf{Requisito} & \textbf{Descrizione} & \textbf{Fonti} \\ 
+\endhead
+    
+\multicolumn{3}{r}{{Continua nella prossima pagina}} \\ 
+\endfoot
+    
+\hline
+\endlastfoot
+
+\hline
+RQ.O.1 & La funzionalità di analisi \gls{seog} deve rispettare le linee guida \gls{wcagg} 2.2, livello AA. & Discussione con la Proponente \\
+\hline
+RQ.OP.2 & L'estensione deve rimanere attiva su tutte le tab. & Discussione con la Proponente \\
+\hline
+RQ.OP.3 & L'utente deve poter aprire e chiudere l'estensione in modo rapido e intuitivo. & Discussione con la Proponente \\
+\end{longtable}
+
+\renewcommand{\arraystretch}{1.5}
+\begin{longtable}{p{0.15\textwidth}p{0.55\textwidth}p{0.2\textwidth}}
+\caption{Tabella dei requisti di vincolo/dominio}
+\label{tab:requisiti-vincolo} \\
+\hline\hline
+\textbf{Requisito} & \textbf{Descrizione} & \textbf{Fonti}\\
+\endfirsthead
+        
+\caption[]{Tabella dei requisiti di vincolo/dominio (continua)} \\
+\hline\hline
+\textbf{Requisito} & \textbf{Descrizione} & \textbf{Fonti} \\ 
+\endhead
+        
+\multicolumn{3}{r}{{Continua nella prossima pagina}} \\ 
+\endfoot
+        
+\hline
+\endlastfoot
+
+\hline
+RV.O.1 & La funzionalità di analisi \gls{seog} deve essere resa disponibile tramite \gls{github} (come codice sorgente) o pubblicata su un'altra piattaforma ad accesso pubblico. & Discussione con la Proponente \\
+\hline
+RV.O.2 & La funzionalità di analisi SEO deve essere integrata all'interno di un'estensione per Chrome & Discussione con la Proponente \\
+\end{longtable}

--- a/chapters/concept.tex
+++ b/chapters/concept.tex
@@ -27,14 +27,13 @@
 
 \begin{usecase}{2}{Visualizzazione di una panoramica dell'analisi delle parole chiave}\label{UC2}
     \usecaseactors{Utente.}
-    \usecasepre{
+    \usecasepreEnv{
         \begin{itemize}
             \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
             \item Il sistema è attivo e funzionante.
-        \end{itemize}
-    }
+        \end{itemize}}
     \usecasepost{Il sistema mostra una panoramica dell'analisi delle parole chiave.}
-    \usecasesub{
+    \usecasesubEnv{
         \begin{itemize}
             \item \hyperref[UC2point1]{UC2.1}: Visualizzazione del meta tag keywords;
             \item \hyperref[UC2point2]{UC2.2}: Visualizzazione del numero totale di parole nella pagina;
@@ -45,12 +44,12 @@
 
 \begin{usecase}{2.1}{Visualizzazione del meta tag keywords}\label{UC2point1}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
     \usecasepost{Il sistema mostra il meta tag keywords.}
-    \usecaseext{
+    \usecaseextEnv{
         \begin{itemize}
             \item Visualizzazione di un avviso se il meta tag keywords non è presente (\hyperref[UC10]{UC10}).
         \end{itemize}}
@@ -58,16 +57,16 @@
 
 \begin{usecase}{2.2}{Visualizzazione del numero totale di parole nella pagina}\label{UC2point2}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
-    \usecasepost{Il sistema il numero totale di parole presenti nella pagina.}
+    \usecasepost{Il sistema mostra il numero totale di parole presenti nella pagina.}
 \end{usecase}
 
 \begin{usecase}{2.3}{Visualizzazione del numero di parole uniche nella pagina}\label{UC2point3}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -76,7 +75,7 @@
 
 \begin{usecase}{2.4}{Visualizzazione della lingua della pagina}\label{UC2point4}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -85,7 +84,7 @@
 
 \begin{usecase}{3}{Inserimento di una parola chiave}\label{UC3}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -95,38 +94,38 @@
 
 \begin{usecase}{4}{Inserimento di una parola chiave}\label{UC4}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
     \usecasedesc{Il sistema esegue l'analisi di una parola chiave scelta dall'utente.}
     \usecasepost{Il sistema aggiunge la parola chiave analizzata alla lista delle keyword.}
-    \usecaseinc{\begin{itemize}
+    \usecaseincEnv{\begin{itemize}
         \item Inserimento di una parola chiave (\hyperref[UC3]{UC3}).
     \end{itemize}}
 \end{usecase}
 
 \begin{usecase}{5}{Visualizzazione di una lista delle parole chiave}\label{UC5}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
     \usecasepost{Il sistema mostra una lista delle parole chiave.}
-    \usecasesub{
+    \usecasesubEnv{
         \begin{itemize}
             \item \hyperref[UC5point1]{UC5.1}: Visualizzazione di una lista delle parole chiave estratte dal meta tag keywords;
             \item \hyperref[UC5point2]{UC5.2}: Visualizzazione di una lista delle parole chiave inserite dall'utente;
             \item \hyperref[UC5point3]{UC5.3}: Visualizzazione di una lista delle parole chiave più frequenti.
         \end{itemize}}
-    \usecaseinc{\begin{itemize}
+    \usecaseincEnv{\begin{itemize}
         \item Visualizzazione di una singola parola chiave (\hyperref[UC6]{UC6}).
     \end{itemize}}
 \end{usecase}
 
 \begin{usecase}{5.1}{Visualizzazione di una lista delle parole chiave}\label{UC5point1}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -135,7 +134,7 @@
 
 \begin{usecase}{5.2}{Visualizzazione di una lista delle parole chiave inserite dall'utente}\label{UC5point2}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -144,7 +143,7 @@
 
 \begin{usecase}{5.3}{Visualizzazione di una lista delle parole chiave inserite dall'utente}\label{UC5point3}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -153,25 +152,25 @@
 
 \begin{usecase}{6}{Visualizzazione di una singola parola chiave}\label{UC6}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante;
         \item È visibile la lista delle parole chiave.
     \end{itemize}}
     \usecasepost{L'utente visualizza una singola parola chiave.}
-    \usecaseinc{\begin{itemize}
+    \usecaseincEnv{\begin{itemize}
         \item Visualizzazione dei risultati dell'analisi di una parola chiave (\hyperref[UC7]{UC7}).
     \end{itemize}}
 \end{usecase}
 
 \begin{usecase}{7}{Visualizzazione dei risultati dell'analisi di una parola chiave}\label{UC7}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
     \usecasepost{L'utente visualizza i risultati dell'analisi di una parola chiave.}
-    \usecasesub{
+    \usecasesubEnv{
         \begin{itemize}
             \item \hyperref[UC7point1]{UC7.1}: Visualizzazione della frequenza di una parola chiave;
             \item \hyperref[UC7point2]{UC7.2}: Visualizzazione della densità di una parola chiave;
@@ -181,7 +180,7 @@
 
 \begin{usecase}{7.1}{Visualizzazione della frequenza di una parola chiave}\label{UC7point1}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -190,38 +189,38 @@
 
 \begin{usecase}{7.2}{Visualizzazione della densità di una parola chiave}\label{UC7point2}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
     \usecasepost{L'utente visualizza la densità di una parola chiave.}
-    \usecaseext{\begin{itemize}
+    \usecaseextEnv{\begin{itemize}
         \item Visualizzazione di un avviso se la densità di una parola chiave è troppo alta (\hyperref[UC11]{UC11}).
     \end{itemize}}
 \end{usecase}
 
 \begin{usecase}{7.3}{Visualizzazione di un elenco dei tag in cui dovrebbe essere presente una parola chiave}\label{UC7point3}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
     \usecasepost{L'utente visualizza un elenco dei tag in cui dovrebbe essere presente una parola chiave.}
-    \usecasesub{\begin{itemize}
+    \usecasesubEnv{\begin{itemize}
         \item \hyperref[UC7point3point1]{UC7.3.1}: Visualizzazione di un singolo tag.
     \end{itemize}}
 \end{usecase}
 
 \begin{usecase}{7.3.1}{Visualizzazione di un singolo tag}\label{UC7point3point1}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante;
         \item L'utente sta visualizzando i risultati dell'analisi di una parola chiave;
         \item È visibile l'elenco dei tag.
     \end{itemize}}
     \usecasepost{L'utente visualizza un singolo tag.}
-    \usecasesub{\begin{itemize}
+    \usecasesubEnv{\begin{itemize}
         \item \hyperref[UC7point3point1point1]{UC7.3.1.1}: Visualizzazione del nome del tag;
         \item \hyperref[UC7point3point1point2]{UC7.3.1.2}: Visualizzazione del numero di occorrenze della parola chiave nel tag.
     \end{itemize}}
@@ -229,7 +228,7 @@
 
 \begin{usecase}{7.3.1.1}{Visualizzazione del nome del tag}\label{UC7point3point1point1}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -238,19 +237,19 @@
 
 \begin{usecase}{7.3.1.2}{Visualizzazione del numero di occorrenze di una parola chiave nel tag}\label{UC7point3point1point2}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
     \usecasepost{L'utente visualizza il numero di occorrenze della parola chiave nel tag.}
-    \usecaseext{\begin{itemize}
+    \usecaseextEnv{\begin{itemize}
         \item Visualizzazione di un avviso se il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia (\hyperref[UC12]{UC12}).
     \end{itemize}}
 \end{usecase}
 
 \begin{usecase}{8}{Evidenziazione di una parola chiave nella pagina}\label{UC8}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -259,7 +258,7 @@
 
 \begin{usecase}{9}{Aggiornamento dell'analisi delle parole chiave}\label{UC9}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -269,7 +268,7 @@
 
 \begin{usecase}{10}{Visualizzazione di un avviso se il meta tag keywords non è presente}\label{UC10}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -278,7 +277,7 @@
 
 \begin{usecase}{11}{Visualizzazione di un avviso se la densità di una parola chiave è troppo alta}\label{UC11}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -287,7 +286,7 @@
 
 \begin{usecase}{12}{Visualizzazione di un avviso se il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia}\label{UC12}
     \usecaseactors{Utente.}
-    \usecasepre{\begin{itemize}
+    \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
@@ -314,7 +313,7 @@
     Codice = & codice numerico univoco \\
 \end{tabular}
     
-\newpage
+\par\vspace{30pt}
 
 \renewcommand{\arraystretch}{1.5}
 \begin{longtable}{p{0.15\textwidth}p{0.55\textwidth}p{0.2\textwidth}}
@@ -415,7 +414,7 @@ RQ.O.1 & La funzionalità di analisi \gls{seog} deve rispettare le linee guida \
 \hline
 RQ.OP.2 & L'estensione deve rimanere attiva su tutte le tab. & Discussione con la Proponente \\
 \hline
-RQ.OP.3 & L'utente deve poter aprire e chiudere l'estensione in modo rapido e intuitivo. & Discussione con la Proponente \\
+RQ.D.3 & L'utente deve poter aprire e chiudere l'estensione in modo rapido e intuitivo. & Discussione con la Proponente \\
 \end{longtable}
 
 \renewcommand{\arraystretch}{1.5}
@@ -442,3 +441,27 @@ RV.O.1 & La funzionalità di analisi \gls{seog} deve essere resa disponibile tra
 \hline
 RV.O.2 & La funzionalità di analisi SEO deve essere integrata all'interno di un'estensione per Chrome & Discussione con la Proponente \\
 \end{longtable}
+
+\par\vspace{20pt}
+
+\subsection{Riepilogo}
+
+\begin{table}[H]
+\centering
+\caption{Tabella di riepilogo dei requisiti}
+\label{tab:riepilogo-requisiti}
+% MAX 12.5cm
+\begin{tabular}{ccccc}
+\hline\hline
+\textbf{Requisito} & \textbf{Obbligatorio} & \textbf{Desiderabile} & \textbf{Opzionale} & \textbf{Totale} \\ 
+\hline
+Funzionale & 19 & 5 & 2 & 26 \\
+\hline
+Di qualità & 1 & 1 & 1 & 3 \\
+\hline 
+Di vincolo/dominio & 2 & 0 & 0 & 2 \\
+\hline
+\textbf{Totale} & 22 & 6 & 3 & \textbf{31} \\ 
+\hline
+\end{tabular}
+\end{table}

--- a/chapters/concept.tex
+++ b/chapters/concept.tex
@@ -10,7 +10,7 @@
 
 \section{Casi d'uso}
 
-\paragraph*{Attori}\\
+\paragraph*{Attori}
 \par L'unico attore coinvolto nell'interazione con il sistema è un \textbf{utente generico} con accesso completo alla funzionalità di analisi \gls{seog}. Di seguito sono elencate alcune tipologie di utenti a cui è rivolto il progetto:
 \begin{itemize}
     \item \textbf{Sviluppatore}: utilizza l'estensione durante lo sviluppo e la produzione di contenuti web;

--- a/chapters/concept.tex
+++ b/chapters/concept.tex
@@ -35,23 +35,23 @@
     \usecasepost{Il sistema mostra una panoramica dell'analisi delle parole chiave.}
     \usecasesubEnv{
         \begin{itemize}
-            \item \hyperref[UC2point1]{UC2.1}: Visualizzazione del meta tag keywords;
+            \item \hyperref[UC2point1]{UC2.1}: Visualizzazione del meta tag `keywords`;
             \item \hyperref[UC2point2]{UC2.2}: Visualizzazione del numero totale di parole nella pagina;
             \item \hyperref[UC2point3]{UC2.3}: Visualizzazione del numero di parole uniche nella pagina;
             \item \hyperref[UC2point4]{UC2.4}: Visualizzazione della lingua della pagina.
         \end{itemize}}
 \end{usecase}
 
-\begin{usecase}{2.1}{Visualizzazione del meta tag keywords}\label{UC2point1}
+\begin{usecase}{2.1}{Visualizzazione del meta tag `keywords`}\label{UC2point1}
     \usecaseactors{Utente.}
     \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
-    \usecasepost{Il sistema mostra il meta tag keywords.}
+    \usecasepost{Il sistema mostra il meta tag `keywords`.}
     \usecaseextEnv{
         \begin{itemize}
-            \item Visualizzazione di un avviso se il meta tag keywords non è presente (\hyperref[UC10]{UC10}).
+            \item Visualizzazione di un avviso se il meta tag `keywords` non è presente (\hyperref[UC10]{UC10}).
         \end{itemize}}
 \end{usecase}
 
@@ -114,7 +114,7 @@
     \usecasepost{Il sistema mostra una lista delle parole chiave.}
     \usecasesubEnv{
         \begin{itemize}
-            \item \hyperref[UC5point1]{UC5.1}: Visualizzazione di una lista delle parole chiave estratte dal meta tag keywords;
+            \item \hyperref[UC5point1]{UC5.1}: Visualizzazione di una lista delle parole chiave estratte dal meta tag `keywords`;
             \item \hyperref[UC5point2]{UC5.2}: Visualizzazione di una lista delle parole chiave inserite dall'utente;
             \item \hyperref[UC5point3]{UC5.3}: Visualizzazione di una lista delle parole chiave più frequenti.
         \end{itemize}}
@@ -123,13 +123,13 @@
     \end{itemize}}
 \end{usecase}
 
-\begin{usecase}{5.1}{Visualizzazione di una lista delle parole chiave}\label{UC5point1}
+\begin{usecase}{5.1}{Visualizzazione di una lista delle parole chiave estratte dal meta tag `keywords`}\label{UC5point1}
     \usecaseactors{Utente.}
     \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
-    \usecasepost{Il sistema mostra una lista delle parole chiave estratte dal meta tag keywords.}
+    \usecasepost{Il sistema mostra una lista delle parole chiave estratte dal meta tag `keywords`.}
 \end{usecase}
 
 \begin{usecase}{5.2}{Visualizzazione di una lista delle parole chiave inserite dall'utente}\label{UC5point2}
@@ -141,7 +141,7 @@
     \usecasepost{Il sistema mostra una lista delle parole chiave inserite dall'utente.}
 \end{usecase}
 
-\begin{usecase}{5.3}{Visualizzazione di una lista delle parole chiave inserite dall'utente}\label{UC5point3}
+\begin{usecase}{5.3}{Visualizzazione di una lista delle parole chiave più frequenti}\label{UC5point3}
     \usecaseactors{Utente.}
     \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
@@ -222,7 +222,7 @@
     \usecasepost{L'utente visualizza un singolo tag.}
     \usecasesubEnv{\begin{itemize}
         \item \hyperref[UC7point3point1point1]{UC7.3.1.1}: Visualizzazione del nome del tag;
-        \item \hyperref[UC7point3point1point2]{UC7.3.1.2}: Visualizzazione del numero di occorrenze della parola chiave nel tag.
+        \item \hyperref[UC7point3point1point2]{UC7.3.1.2}: Visualizzazione del numero di occorrenze di una parola chiave nel tag.
     \end{itemize}}
 \end{usecase}
 
@@ -241,7 +241,7 @@
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
-    \usecasepost{L'utente visualizza il numero di occorrenze della parola chiave nel tag.}
+    \usecasepost{L'utente visualizza il numero di occorrenze di una parola chiave nel tag.}
     \usecaseextEnv{\begin{itemize}
         \item Visualizzazione di un avviso se il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia (\hyperref[UC12]{UC12}).
     \end{itemize}}
@@ -262,17 +262,17 @@
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
-    \usecasedesc{L'utente attiva manualmente l'aggiornamento dell'analisi delle parole chiave per sincronizzarla con eventuali modifiche dinamiche al DOM.}
+    \usecasedesc{L'utente aggiorna manualmente l'analisi delle parole chiave per sincronizzarla con eventuali modifiche dinamiche al DOM.}
     \usecasepost{Il sistema aggiorna l'analisi delle parole chiave.}
 \end{usecase}
 
-\begin{usecase}{10}{Visualizzazione di un avviso se il meta tag keywords non è presente}\label{UC10}
+\begin{usecase}{10}{Visualizzazione di un avviso se il meta tag `keywords` non è presente}\label{UC10}
     \usecaseactors{Utente.}
     \usecasepreEnv{\begin{itemize}
         \item L'utente ha selezionato la funzionalità di analisi delle parole chiave;
         \item Il sistema è attivo e funzionante.
     \end{itemize}}
-    \usecasepost{Il sistema mostra un avviso in cui notifica all'utente che il meta tag keywords non è presente.}
+    \usecasepost{Il sistema mostra un avviso in cui notifica all'utente che il meta tag `keywords` non è presente.}
 \end{usecase}
 
 \begin{usecase}{11}{Visualizzazione di un avviso se la densità di una parola chiave è troppo alta}\label{UC11}
@@ -339,7 +339,7 @@ RF.O.1 & L'utente deve poter accedere alla funzionalità di analisi delle parole
 \hline
 RF.O.2 & L'utente deve poter visualizzare una panoramica dell'analisi delle parole chiave. & \hyperref[UC2]{UC2} \\
 \hline
-RF.O.3 & L'utente deve poter visualizzare il meta tag keywords. & \hyperref[UC2point1]{UC2.1} \\
+RF.O.3 & L'utente deve poter visualizzare il meta tag `keywords`. & \hyperref[UC2point1]{UC2.1} \\
 \hline
 RF.O.4 & L'utente deve poter visualizzare il numero totale di parole nella pagina. & \hyperref[UC2point2]{UC2.2} \\
 \hline
@@ -353,7 +353,7 @@ RF.O.8 & L'utente deve poter analizzare una parola chiave. & \hyperref[UC4]{UC4}
 \hline
 RF.O.9 & L'utente deve poter visualizzare una lista delle parole chiave. & \hyperref[UC5]{UC5} \\
 \hline
-RF.O.10 & L'utente deve poter visualizzare una lista delle parole chiave estratte dal meta tag keywords. & \hyperref[UC5point1]{UC5.1} \\
+RF.O.10 & L'utente deve poter visualizzare una lista delle parole chiave estratte dal meta tag `keywords`. & \hyperref[UC5point1]{UC5.1} \\
 \hline
 RF.O.11 & Il sistema deve visualizzare una lista delle parole chiave inserite dall'utente. & \hyperref[UC5point2]{UC5.2} \\
 \hline
@@ -379,13 +379,13 @@ RF.O.21 & Il sistema deve evidenziare tutte le occorrenze di una parola chiave n
 \hline
 RF.O.22 & L'utente deve poter aggiornare l'analisi delle parole chiave. & \hyperref[UC9]{UC9} \\
 \hline
-RF.O.23 & Il sistema deve mostrare un avviso se il meta tag keywords non è presente. & \hyperref[UC10]{UC10} \\
+RF.O.23 & Il sistema deve mostrare un avviso se il meta tag `keywords` non è presente. & \hyperref[UC10]{UC10} \\
 \hline
 RF.O.24 & Il sistema deve mostrare un avviso se la densità di una parola chiave è troppo alta. & \hyperref[UC11]{UC11} \\
 \hline
 RF.D.25 & Il sistema deve mostrare un avviso se il numero di occorrenze di una parola chiave nel tag è inferiore a una certa soglia. & \hyperref[UC12]{UC12} \\
 \hline
-RF.O.26 & Il sistema deve evidenziare le parole chiave con colori diversi in base al tag HTML che le racchiude. & Discussione con la Proponente \\
+RF.O.26 & Il sistema deve evidenziare le parole chiave con colori diversi in base al tag \gls{htmlg} che le racchiude. & Discussione con la Proponente \\
 \end{longtable}
 
 \newpage

--- a/config/packages.tex
+++ b/config/packages.tex
@@ -63,3 +63,5 @@
 \usepackage{fancyhdr}
 
 \usepackage{float}
+\usepackage{enumitem}
+

--- a/config/thesis-config.tex
+++ b/config/thesis-config.tex
@@ -168,25 +168,31 @@
     \renewcommand{\theusecasecounter}{\usecasename #1}  % this is where the display of
                                                         % the counter is overwritten/modified
     \refstepcounter{usecasecounter}             % increment counter
-    \vspace{10pt}
-    \par \noindent                              % start new paragraph
-    {\large \textbf{\usecasename #1: #2}}       % display the title before the
-                                                % content of the environment is displayed
-    \medskip
+    %\vspace{10pt}
+    \section*{\large \usecasename #1: #2}   % display the title before the
+                                            % content of the environment is displayed
 }{
-    \medskip
+    %\medskip
 }
 
 \newcommand{\usecasename}{UC}
 
-\newcommand{\usecaseactors}[1]{\par\textbf{\\Attori Principali}: #1}
-\newcommand{\usecasepre}[1]{\par\textbf{\\Precondizioni}: #1}
-\newcommand{\usecasedesc}[1]{\par\textbf{\\Descrizione}: #1}
-\newcommand{\usecasepost}[1]{\par\textbf{\\Postcondizioni}: #1}
-\newcommand{\usecasealt}[1]{\par\textbf{\\Scenario Alternativo}: #1}
-\newcommand{\usecasesub}[1]{\par\textbf{\\Sottocasi d'uso}: #1}
-\newcommand{\usecaseinc}[1]{\par\textbf{\\Inclusioni}: #1}
-\newcommand{\usecaseext}[1]{\par\textbf{\\Scenario Alternativo}: #1}
+\newcommand{\usecaseactors}[1]{\par\noindent\textbf{Attori Principali}: #1\medskip}
+\newcommand{\usecasepre}[1]{\par\noindent\textbf{Precondizioni}: #1\medskip}
+\newcommand{\usecasedesc}[1]{\par\noindent\textbf{Descrizione}: #1\medskip}
+\newcommand{\usecasepost}[1]{\par\noindent\textbf{Postcondizioni}: #1\medskip}
+\newcommand{\usecasealt}[1]{\par\noindent\textbf{Scenario Alternativo}: #1\medskip}
+\newcommand{\usecasesub}[1]{\par\noindent\textbf{Sottocasi d'uso}: #1\medskip}
+\newcommand{\usecaseinc}[1]{\par\noindent\textbf{Inclusioni}: #1\medskip}
+\newcommand{\usecaseext}[1]{\par\noindent\textbf{Estensioni}: #1\medskip}
+\newcommand{\usecaseactorsEnv}[1]{\par\noindent\textbf{Attori Principali}: #1}
+\newcommand{\usecasepreEnv}[1]{\par\noindent\textbf{Precondizioni}: #1}
+\newcommand{\usecasedescEnv}[1]{\par\noindent\textbf{Descrizione}: #1}
+\newcommand{\usecasepostEnv}[1]{\par\noindent\textbf{Postcondizioni}: #1}
+\newcommand{\usecasealtEnv}[1]{\par\noindent\textbf{Scenario Alternativo}: #1}
+\newcommand{\usecasesubEnv}[1]{\par\noindent\textbf{Sottocasi d'uso}: #1}
+\newcommand{\usecaseincEnv}[1]{\par\noindent\textbf{Inclusioni}: #1}
+\newcommand{\usecaseextEnv}[1]{\par\noindent\textbf{Estensioni}: #1}
 
 % Namespace description environment
 \newenvironment{namespacedesc}{

--- a/config/thesis-config.tex
+++ b/config/thesis-config.tex
@@ -46,6 +46,7 @@
 \input{config/variables}
 
 \input{appendix/glossary-entries}
+\renewcommand*{\glspostdescription}{}
 \makeglossaries
 
 \bibliography{appendix/bibliography}

--- a/config/thesis-config.tex
+++ b/config/thesis-config.tex
@@ -179,11 +179,14 @@
 
 \newcommand{\usecasename}{UC}
 
-\newcommand{\usecaseactors}[1]{\textbf{\\Attori Principali:} #1. \vspace{4pt}}
-\newcommand{\usecasepre}[1]{\textbf{\\Precondizioni:} #1. \vspace{4pt}}
-\newcommand{\usecasedesc}[1]{\textbf{\\Descrizione:} #1. \vspace{4pt}}
-\newcommand{\usecasepost}[1]{\textbf{\\Postcondizioni:} #1. \vspace{4pt}}
-\newcommand{\usecasealt}[1]{\textbf{\\Scenario Alternativo:} #1. \vspace{4pt}}
+\newcommand{\usecaseactors}[1]{\par\textbf{\\Attori Principali}: #1}
+\newcommand{\usecasepre}[1]{\par\textbf{\\Precondizioni}: #1}
+\newcommand{\usecasedesc}[1]{\par\textbf{\\Descrizione}: #1}
+\newcommand{\usecasepost}[1]{\par\textbf{\\Postcondizioni}: #1}
+\newcommand{\usecasealt}[1]{\par\textbf{\\Scenario Alternativo}: #1}
+\newcommand{\usecasesub}[1]{\par\textbf{\\Sottocasi d'uso}: #1}
+\newcommand{\usecaseinc}[1]{\par\textbf{\\Inclusioni}: #1}
+\newcommand{\usecaseext}[1]{\par\textbf{\\Scenario Alternativo}: #1}
 
 % Namespace description environment
 \newenvironment{namespacedesc}{

--- a/structure.tex
+++ b/structure.tex
@@ -22,7 +22,7 @@
         %\input{chapters/introduzione}
         %\input{chapters/processi}
         %\input{chapters/kick-off}
-        %\input{chapters/concept}
+        \input{chapters/concept}
         %\input{chapters/product-prototype}
         %\input{chapters/product-design}
         %\input{chapters/conclusioni}


### PR DESCRIPTION
Ho completato l'analisi dei requisiti.

Ho apportato le seguenti modifiche al template:

- Rimosso il punto automatico alla fine della descrizione di acronimi ed entry del glossario;
- Modificato l'ambiente per la descrizione dei casi d'uso:
    - Invece di creare un paragrafo per il titolo, ho usato `\section*` (una sezione non indicizzata);
    - Ho rimosso i comandi `\vspace` e `\medskip` superflui;
    - Ho aggiunto `\par\noindent` e `\medskip` a ciascun comando;
    - Ho aggiunto la versione **_Env_** dei comandi senza il `\medskip`, in quanto l'utilizzo di ambienti prevede già degli spazi automatici.
- Aggiunto il pacchetto **_enumitem_**.